### PR TITLE
chore(tmux): re-enable osc52 in tmux

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -15,40 +15,40 @@ set -g prefix C-a
 bind C-a send-prefix
 
 # Key bindings
- 
+
 # reload settings
 bind-key R source-file ~/.tmux.conf
- 
+
 # detach client
 bind-key d detach
 bind-key C-d detach
- 
+
 # choose a client to detach
 bind-key D choose-client
- 
+
 # choose window/session
 # bind-key "'" choose-window
 # bind-key '"' choose-session
 
 # display visible indicator of each pane
 bind-key w display-panes
- 
+
 # navigate panes using jk, and ctrl+jk (no prefix)
 bind-key -r j select-pane -D
 bind-key -r k select-pane -U
 bind-key -r C-j select-pane -D
 bind-key -r C-k select-pane -U
- 
+
 # navigate windows using hl, and ctrl-hl (no prefix)
 bind-key -r h select-window -t :-
 bind-key -r l select-window -t :+
 bind-key -r C-h select-pane -L
 bind-key -r C-l select-pane -R
- 
+
 # swap panes
 bind-key -r J swap-pane -D
 bind-key -r K swap-pane -U
- 
+
 # Cycle to next pane
 bind-key -r Tab select-pane -t :.+
 
@@ -71,14 +71,9 @@ set -g mouse on
 unbind p
 bind p paste-buffer
 bind-key -T copy-mode-vi 'v' send -X begin-selection
-bind-key -T copy-mode-vi 'y' send-keys -X copy-pipe-and-cancel 'xclip -se c -i'
 
-# TODO: osc52 is causing tmux to crash
-# maybe related? https://github.com/tmux/tmux/issues/3068
-# to reproduce: printf "\033]52;c;$(printf "%s" "blabla" | base64)\a" inside tmux
-set -s set-clipboard off
-# set -s set-clipboard on
-# bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+set -s set-clipboard on
+bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
 
 bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"


### PR DESCRIPTION
This has been [patched in slackware](https://www.linuxquestions.org/questions/slackware-14/current-tmux-crash-4175726339/) today (July 25 2023).
Relevant tmux issue: https://github.com/tmux/tmux/issues/3539
The patch: https://github.com/tmux/tmux/commit/8f34504736cf3547992c4ba948c1e65f3813715c
It was caused by an update to ncurses>=6.4-20230424

Closes #1965 