### PR TITLE
chore(ci): remove redundant dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
       - name: deps
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: stow libglib2.0-dev libmpv-dev dbus-x11 dconf-cli ninja-build
+          packages: stow libglib2.0-dev libmpv-dev dbus-x11 dconf-cli
           # libglib2.0-dev libmpv-dev - mpv-mpris
           # dbus-x11 dconf-cli - ibus
-          # ninja-build - lua-language-server
           version: 1.0
       - name: neovim
         uses: rhysd/action-setup-vim@v1


### PR DESCRIPTION
I no longer build lua-language-server locally (use mason to install instead) so remove this