### PR TITLE
ci: fetch full history and tags in the test job's checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+          # full history + tags for the superproject and submodules, so builds that rely on
+          # `git describe --tags` (e.g. deps/ccls, or a submodule's own build tooling) behave
+          # the same as a real local clone instead of depending on shallow-clone shape
+          fetch-depth: 0
       - name: install rust toolchain
         uses: actions-rs/toolchain@v1 # atuin
         with:


### PR DESCRIPTION
## Summary
- The `test` job's `actions/checkout` defaulted to a shallow (depth-1), tag-less clone of the superproject and its recursive submodules.
- This let CI silently diverge from a real local clone for anything that relies on `git describe --tags` inside a submodule — e.g. it's what masked the `avante.nvim` `build.sh` release/tag-mismatch bug from CI entirely (`build.sh` fell into its "no tag found, build from source" branch by accident, rather than exercising the actual buggy release-download path that a real local clone hits).
- Rather than maintain an allowlist of which submodules need tags (which drifts as soon as one is missed), just fetch full history for everything via `fetch-depth: 0`.

## Test plan
- [ ] CI passes on this PR
- [ ] `test` job checkout step shows a full (non-shallow) clone of submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)